### PR TITLE
Add Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+# statit files
+public/
+
+# next.js
+.next/
+out/
+
+# production
+build/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # EZRoutine
+
 Web app about creating minimalist routines and lifestyle advices .

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "ezroutine",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ezroutine",
+      "workspaces": [
+        "./apps/*"
+      ],
+      "devDependencies": {
+        "prettier": "2.7.1",
+        "prettier-plugin-tailwindcss": "0.1.13"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.13.tgz",
+      "integrity": "sha512-/EKQURUrxLu66CMUg4+1LwGdxnz8of7IDvrSLqEtDqhLH61SAlNNUSr90UTvZaemujgl3OH/VHg+fyGltrNixw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.17.0"
+      },
+      "peerDependencies": {
+        "prettier": ">=2.2.0"
+      }
+    }
+  },
+  "dependencies": {
+    "prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true
+    },
+    "prettier-plugin-tailwindcss": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.13.tgz",
+      "integrity": "sha512-/EKQURUrxLu66CMUg4+1LwGdxnz8of7IDvrSLqEtDqhLH61SAlNNUSr90UTvZaemujgl3OH/VHg+fyGltrNixw==",
+      "dev": true,
+      "requires": {}
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,5 +12,12 @@
   "homepage": "https://github.com/Chemuki/EZRoutine#readme",
   "workspaces": [
     "./apps/*"
-  ]
+  ],
+  "scripts": {
+    "format": "prettier --write . "
+  },
+  "devDependencies": {
+    "prettier": "2.7.1",
+    "prettier-plugin-tailwindcss": "0.1.13"
+  }
 }


### PR DESCRIPTION
Install prettier, prettier-plugin-tailwindcss, and add a .prettierignore file to avoid format public files or files from builds.

- [x]  Install Prettier
- [x]  Install prettier-plugin-tailwindcss
- [x]  Create a .prettierignore file
- [x]  Add script to format all package code/files caching it