### PR TITLE
Add --cache flag and config to Prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,19 +1,19 @@
 {
-  "env": {
-    "browser": true,
-    "es2021": true,
-    "node": true
-  },
-  "extends": ["standard", "standard-jsx", "prettier"],
-  "overrides": [],
-  "parserOptions": {
-    "ecmaVersion": "latest",
-    "sourceType": "module"
-  },
-  "plugins": ["simple-import-sort"],
-  "rules": {
-    "simple-import-sort/imports": "error",
-    "simple-import-sort/exports": "error"
-  },
-  "ignorePatterns": ["public/", ".next/", "out/", "build/"]
+	"env": {
+		"browser": true,
+		"es2021": true,
+		"node": true
+	},
+	"extends": ["standard", "standard-jsx", "prettier"],
+	"overrides": [],
+	"parserOptions": {
+		"ecmaVersion": "latest",
+		"sourceType": "module"
+	},
+	"plugins": ["simple-import-sort"],
+	"rules": {
+		"simple-import-sort/imports": "error",
+		"simple-import-sort/exports": "error"
+	},
+	"ignorePatterns": ["public/", ".next/", "out/", "build/"]
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+	"trailingComma": "all",
+	"useTabs": true
+}

--- a/package.json
+++ b/package.json
@@ -1,33 +1,33 @@
 {
-  "name": "ezroutine",
-  "private": true,
-  "description": "Web app about creating minimalist routines and lifestyle advices .",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Chemuki/EZRoutine.git"
-  },
-  "bugs": {
-    "url": "https://github.com/Chemuki/EZRoutine/issues"
-  },
-  "homepage": "https://github.com/Chemuki/EZRoutine#readme",
-  "workspaces": [
-    "./apps/*"
-  ],
-  "scripts": {
-    "format": "prettier --write . ",
-    "lint" : "eslint --fix --cache ."
-  },
-  "devDependencies": {
-    "eslint": "8.24.0",
-    "eslint-config-prettier": "8.5.0",
-    "eslint-config-standard": "17.0.0",
-    "eslint-config-standard-jsx": "11.0.0",
-    "eslint-plugin-import": "2.26.0",
-    "eslint-plugin-n": "15.3.0",
-    "eslint-plugin-promise": "6.0.1",
-    "eslint-plugin-react": "7.31.8",
-    "eslint-plugin-simple-import-sort": "8.0.0",
-    "prettier": "2.7.1",
-    "prettier-plugin-tailwindcss": "0.1.13"
-  }
+	"name": "ezroutine",
+	"private": true,
+	"description": "Web app about creating minimalist routines and lifestyle advices .",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Chemuki/EZRoutine.git"
+	},
+	"bugs": {
+		"url": "https://github.com/Chemuki/EZRoutine/issues"
+	},
+	"homepage": "https://github.com/Chemuki/EZRoutine#readme",
+	"workspaces": [
+		"./apps/*"
+	],
+	"scripts": {
+		"format": "prettier --write --cache .",
+		"lint": "eslint --fix --cache ."
+	},
+	"devDependencies": {
+		"eslint": "8.24.0",
+		"eslint-config-prettier": "8.5.0",
+		"eslint-config-standard": "17.0.0",
+		"eslint-config-standard-jsx": "11.0.0",
+		"eslint-plugin-import": "2.26.0",
+		"eslint-plugin-n": "15.3.0",
+		"eslint-plugin-promise": "6.0.1",
+		"eslint-plugin-react": "7.31.8",
+		"eslint-plugin-simple-import-sort": "8.0.0",
+		"prettier": "2.7.1",
+		"prettier-plugin-tailwindcss": "0.1.13"
+	}
 }


### PR DESCRIPTION
# Description

Add --cache CLI option to avoid format unmodified files.

Set trailingComma config to mach with default value in [Prettier v3](https://github.com/prettier/prettier/releases).

Set useTabs config to `true` to make the [code more accessible](https://github.com/prettier/prettier/issues/7475).

# To-do

- [x]  Add --cache flag to format script
- [x]  Set Prettier trailingComma config to `"all"`
- [x]  Set Prettier useTabs config to `true`.